### PR TITLE
Fix check for `collect_function_metrics` key

### DIFF
--- a/templates/default/postgres.yaml.erb
+++ b/templates/default/postgres.yaml.erb
@@ -25,7 +25,7 @@ instances:
       - <%= r %>
         <% end -%>
     <% end -%>
-    <% if i.keys?("collect_function_metrics") -%>
+    <% if i.key?("collect_function_metrics") -%>
     collect_function_metrics: i["collect_function_metrics"]
     <% end -%>
 <% end -%>


### PR DESCRIPTION
This fixes the postgres template when checking for the `collect_function_metrics` key.
